### PR TITLE
Add a 'launch.json' file to make it easy to run 'serve.py' when debugging functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,6 @@ dmypy.json
 .pyre/
 
 # VS/VS Code settings
-/.vs*/
+/.vs/
+/.vscode/*
+!/.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Functions",
+            "type": "python",
+            "request": "launch",
+            "program": ".scripts/serve.py",
+            "console": "integratedTerminal"
+        }
+    ]
+}


### PR DESCRIPTION
This should be helpful, since users are editing 'Functions.py,' but should be running 'serve.py' when debugging.