### PR TITLE
Use JavaScript from github host instead of unstable azurewebsites.net

### DIFF
--- a/.scripts/serve.py
+++ b/.scripts/serve.py
@@ -64,7 +64,7 @@ def _getPageHtml(devMode = False) -> str:
     if devMode:
         host = "localhost:8080"
     else:
-        host = "exceljupyter.azurewebsites.net"
+        host = "shaofengzhu.github.io/office-addin/excel-codespace"
     return pageHtmlFormat.format(host)
 
 

--- a/.scripts/serve.py
+++ b/.scripts/serve.py
@@ -73,7 +73,7 @@ def _getPageHtml(devMode = False) -> str:
     if devMode:
         host = "localhost:8080"
     else:
-        host = "shaofengzhu.github.io/office-addin/excel-codespace"
+        host = "officedev.github.io/custom-functions/lib/excel-codespace"
     return pageHtmlFormat.format(host)
 
 

--- a/static/main.html
+++ b/static/main.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8" />
     <title>Custom Functions</title>
     <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css">
-    <script src="https://exceljupyter.azurewebsites.net/agave/external/react-16-12-0/umd/react.development.js"></script>
-    <script src="https://exceljupyter.azurewebsites.net/agave/external/react-dom-16-12-0/umd/react-dom.development.js"></script>
+    <script src="https://shaofengzhu.github.io/office-addin/excel-codespace/agave/external/react-16-12-0/umd/react.development.js"></script>
+    <script src="https://shaofengzhu.github.io/office-addin/excel-codespace/agave/external/react-dom-16-12-0/umd/react-dom.development.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.debug.js"></script>
-    <script type="text/javascript" src="https://exceljupyter.azurewebsites.net/agave/custom-function-forwarder.bundle.js"></script>
+    <script type="text/javascript" src="https://shaofengzhu.github.io/office-addin/excel-codespace/agave/custom-function-forwarder.bundle.js"></script>
 </head>
     <body>
         <div id="DivApp">

--- a/static/main.html
+++ b/static/main.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8" />
     <title>Custom Functions</title>
     <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css">
-    <script src="https://shaofengzhu.github.io/office-addin/excel-codespace/agave/external/react-16-12-0/umd/react.development.js"></script>
-    <script src="https://shaofengzhu.github.io/office-addin/excel-codespace/agave/external/react-dom-16-12-0/umd/react-dom.development.js"></script>
+    <script src="https://officedev.github.io/custom-functions/lib/excel-codespace/agave/external/react-16-12-0/umd/react.development.js"></script>
+    <script src="https://officedev.github.io/custom-functions/lib/excel-codespace/agave/external/react-dom-16-12-0/umd/react-dom.development.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.debug.js"></script>
-    <script type="text/javascript" src="https://shaofengzhu.github.io/office-addin/excel-codespace/agave/custom-function-forwarder.bundle.js"></script>
+    <script type="text/javascript" src="https://officedev.github.io/custom-functions/lib/excel-codespace/agave/custom-function-forwarder.bundle.js"></script>
 </head>
     <body>
         <div id="DivApp">


### PR DESCRIPTION
I used to host JavaScript in the exceljupyter.azurewebsites.net. The website is always down for unknown reason. We now put the script on github.